### PR TITLE
Add the MultiMode DAE failure example

### DIFF
--- a/FailureModes/AlgebraicLoop.mo
+++ b/FailureModes/AlgebraicLoop.mo
@@ -1,0 +1,58 @@
+within FailureModes;
+package AlgebraicLoop "An example of generating algebraic loop"
+  extends Modelica.Icons.ExamplesPackage;
+  model WithoutAlgebraicLoop "An normal example without algebraic loop"
+    extends Modelica.Icons.Example;
+    Real x;
+    Real y(start=1, fixed=true);
+  equation
+    when x > 0.5 then
+      y = 1*time;
+    end when;
+    x = sin(10*time);
+  end WithoutAlgebraicLoop;
+
+  model WithAlgebraicLoop_Wrong "An example of generating algebraic loop"
+    extends Modelica.Icons.Example;
+    Real x;
+    Real y(start=1, fixed=true);
+  equation
+    when x > 0.5 then
+      y = 1*time;
+    end when;
+    x = sin(y*10*time);
+  end WithAlgebraicLoop_Wrong;
+
+  model WithAlgebraicLoop_Wrong2 "Demonstration of how to avoid generating algebraic loop,
+  but end up with internal error in code generation for pre"
+    extends Modelica.Icons.Example;
+    Real x;
+    Real y(start=1, fixed=true);
+  equation
+    when pre(x > 0.5) then
+      y = 1*time;
+    end when;
+    x = sin(y*10*time);
+  end WithAlgebraicLoop_Wrong2;
+
+  model WithAlgebraicLoop_Right "Demonstration of how to avoid generating algebraic loop"
+    extends Modelica.Icons.Example;
+    Real x;
+    Real y(start=1, fixed=true);
+    Boolean cond;
+  equation
+    cond = x > 0.5;
+    when pre(cond) then
+      y = 1*time;
+    end when;
+    x = sin(y*10*time);
+  end WithAlgebraicLoop_Right;
+  annotation (                                 Documentation(info="<html>
+<p>This package includes a few related examples to illustrate:</p>
+<ul>
+<li>why using when clause would generate algebraic loops;</li>
+<li>how to use <a href=\"ModelicaReference.Operators.'pre()'\">`pre` operator </a>to avoid algebraic loops;</li>
+</ul>
+<p>See more discussions at Stack Overflow.<a href=\"https://stackoverflow.com/a/8028369/12160919\">[1]</a> and <a href=\"https://stackoverflow.com/a/65123167/12160919\">[2]</a></p>
+</html>"));
+end AlgebraicLoop;

--- a/FailureModes/MultiModeDAE.mo
+++ b/FailureModes/MultiModeDAE.mo
@@ -1,0 +1,28 @@
+﻿within FailureModes;
+package MultiModeDAE "A collection of MultiModeDAE examples"
+  extends Modelica.Icons.ExamplesPackage;
+  model MultiModeDAE
+    extends Modelica.Icons.Example;
+    Real x(start=100,fixed=true);
+  equation
+    if time<=0.5 then
+      x=100;
+    else
+      der(x)=5;
+    end if;
+    annotation (Documentation(info="<html>
+
+<p>Multimode DAE systems constitute the mathematical framework supporting the physical modeling of systems possessing different modes. 
+Each mode exhibits different dynamics, captured by Differential Algebraic Equations (DAEs).
+ Multimode DAE systems are the underlying framework of ‘object-oriented’ modeling languages such as Modelica, Amesim, or Simscape. 
+But in most of the Modelica modeling environment, the current solvers used could NOT deal with Multimode DAE appropriately.</p>
+
+<p>In this example model, the if statement includes two branches that have a different differential index. Although the model doesn't violate Modelica Specification, it still gets a runtime error at time = 0. It is beneficial if the simulation environment could give such information regarding the different differential indexes in different branches. </p>
+
+Here are some discussions on <a href=\"https://stackoverflow.com/questions/65199823/an-error-of-using-multi-mode-daes-in-dymola/65216999#65216999\">Stack Overflow</a>  and <a href=\"https://github.com/modelica/ModelicaSpecification/issues/2411\">Github</a> Github.
+
+
+See <a href=\"https://hal.inria.fr/hal-03045498/file/JARAP_726%20%281%29.pdf\">paper 1</a> and <a href=\"http://people.rennes.inria.fr/Albert.Benveniste/pub/MultimodeDAE_LNCS10000.pdf\">paper 2</a> for some information on how to solve Multimode DAE.
+</html>"));
+  end MultiModeDAE;
+end MultiModeDAE;

--- a/FailureModes/package.order
+++ b/FailureModes/package.order
@@ -3,4 +3,5 @@ DifferentialSolverFailures
 Chattering
 SingularModels
 MultiModeDAE
+AlgebraicLoop
 Utilities

--- a/FailureModes/package.order
+++ b/FailureModes/package.order
@@ -2,4 +2,5 @@ NonlinearSolverFailures
 DifferentialSolverFailures
 Chattering
 SingularModels
+MultiModeDAE
 Utilities


### PR DESCRIPTION
Create a new subpackage that includes the MultiMode DAE failure example. Short documentation is added to illustrate the details and give more resources about dealing with MultiMode DAE.